### PR TITLE
v1.0.2

### DIFF
--- a/.changeset/serious-eels-appear.md
+++ b/.changeset/serious-eels-appear.md
@@ -1,0 +1,6 @@
+---
+"@discordkit/client": patch
+"@discordkit/core": patch
+---
+
+Actually fix missing build artifacts 😰

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Announce new release to Discord Channel
-        uses: ./apps/webhook-action
+        uses: ./apps/webhook-action/action.yml
         if: steps.changesets.outputs.published == 'true'
         with:
           webhook: ${{ secrets.DISCORD_WEBHOOK_ID }}

--- a/apps/webhook-action/action.yml
+++ b/apps/webhook-action/action.yml
@@ -13,4 +13,4 @@ inputs:
     required: true
 runs:
   using: "node20"
-  main: "dist/index.js"
+  main: "./dist/index.js"

--- a/apps/webhook-action/package.json
+++ b/apps/webhook-action/package.json
@@ -1,5 +1,6 @@
 {
   "name": "webhook-action",
+  "version": "0.0.2",
   "description": "Enables a GitHub Action to send a message to Discord via webhooks.",
   "license": "MIT",
   "author": "Drake Costa <drake@saeris.gg> (https://saeris.gg)",
@@ -25,6 +26,5 @@
     ],
     "minify": true,
     "treeshake": true
-  },
-  "version": null
+  }
 }

--- a/package.json
+++ b/package.json
@@ -24,9 +24,7 @@
     "build:packages": "turbo run build",
     "lint": "eslint \"./{apps,examples,packages,scripts}/**/*.{j,t}s?(x)\" --cache",
     "format": "yarn lint --fix",
-    "prepublishOnly": "turbo run build build:cjs",
-    "prepack": "turbo run build",
-    "release": "changeset publish",
+    "release": "turbo run build build:cjs && changeset publish",
     "test": "vitest --single-thread",
     "version": "changeset version"
   },


### PR DESCRIPTION
Turns out, `@changesets/cli ` doesn't actually run a command which triggers `prepublishOnly` 😅
