### PR TITLE
v1.0.3

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -6,6 +6,7 @@
   ],
   "commit": false,
   "linked": [["@discordkit/client", "@discordkit/core"]],
+  "ignore": ["webhook-action", "with-nextjs"],
   "access": "public",
   "baseBranch": "main"
 }

--- a/.changeset/quiet-cherries-approve.md
+++ b/.changeset/quiet-cherries-approve.md
@@ -1,0 +1,6 @@
+---
+"@discordkit/client": patch
+"@discordkit/core": patch
+---
+
+Added a new versioning script to workaround `@changeset/cli`'s inability to correctly run `yarn npm publish`, which accidentally leaves workspace protocol dependency versions unchanged and published to npm. Shoutout to https://github.com/PrairieLearn/PrairieLearn/pull/7533 for the fix.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Announce new release to Discord Channel
-        uses: ./apps/webhook-action/action.yml
+        uses: ./apps/webhook-action
         if: steps.changesets.outputs.published == 'true'
         with:
           webhook: ${{ secrets.DISCORD_WEBHOOK_ID }}

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "build:packages": "turbo run build",
     "lint": "eslint \"./{apps,examples,packages,scripts}/**/*.{j,t}s?(x)\" --cache",
     "format": "yarn lint --fix",
-    "release": "turbo run build build:cjs && changeset publish",
+    "release": "turbo run build build:cjs && tsx ./scripts/version.ts && changeset publish",
     "test": "vitest --single-thread",
     "version": "changeset version"
   },
@@ -52,6 +52,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "rimraf": "^5.0.5",
+    "tsx": "^3.13.0",
     "turbo": "1.10.14",
     "type-fest": "^4.3.3",
     "typescript": "5.2.2",

--- a/scripts/version.ts
+++ b/scripts/version.ts
@@ -1,0 +1,84 @@
+// Adapted from https://github.com/PrairieLearn/PrairieLearn/pull/7533
+//
+// Changesets doesn't currently support workspace versions:
+// https://github.com/changesets/changesets/issues/432
+// https://github.com/changesets/action/issues/246
+// To work around that, we'll manually resolve any `workspace:` version ranges
+// with this tool prior to publishing. If/when changesets adds native support
+// for publishing with Yarn 3, we can remove this script.
+// We'll only support the `workspace:^` range, which is the only one we
+// generally want to use.
+
+import cp from "node:child_process";
+import fs from "node:fs/promises";
+import path from "node:path";
+import util from "node:util";
+
+const DEPENDENCY_TYPES = [
+  `dependencies`,
+  `devDependencies`,
+  `peerDependencies`
+];
+
+const exec = util.promisify(cp.exec);
+
+const rawWorkspaces = await exec(`yarn workspaces list --json`, {
+  encoding: `utf8`
+});
+
+const workspaces = rawWorkspaces.stdout
+  .trim()
+  .split(`\n`)
+  .map((line) => JSON.parse(line))
+  .filter((workspace) => workspace.location !== `.`);
+
+// Get the version of each workspace package.
+const workspaceVersions = new Map(
+  await Promise.all(
+    workspaces.map<Promise<[name: string, version: string]>>(
+      async (workspace) => {
+        const packageJsonPath = path.join(workspace.location, `package.json`);
+        const packageJson = JSON.parse(
+          await fs.readFile(packageJsonPath, `utf8`)
+        );
+        return [workspace.name, packageJson.version];
+      }
+    )
+  )
+);
+
+// Replace any `workspace:^` version ranges with the actual version.
+await Promise.all(
+  workspaces.map(async (workspace) => {
+    const packageJsonPath = path.join(workspace.location, `package.json`);
+    const packageJson = JSON.parse(await fs.readFile(packageJsonPath, `utf8`));
+
+    for (const dependencyType of DEPENDENCY_TYPES) {
+      const dependencies = Object.keys(packageJson[dependencyType] ?? {});
+      for (const dependency of dependencies) {
+        const dependencyVersion = packageJson[dependencyType][dependency];
+        if (dependencyVersion.startsWith(`workspace:`)) {
+          if (!dependencyVersion.startsWith(`workspace:^`)) {
+            throw new Error(
+              `Unsupported workspace version range: ${dependencyVersion}`
+            );
+          }
+
+          const realVersion = workspaceVersions.get(dependency);
+          if (!realVersion) {
+            throw new Error(
+              `Could not find version for workspace ${dependency}`
+            );
+          }
+
+          packageJson[dependencyType][dependency] = `^${realVersion}`;
+        }
+      }
+    }
+
+    await fs.writeFile(
+      packageJsonPath,
+      `${JSON.stringify(packageJson, null, 2)}\n`
+    );
+  })
+);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2164,6 +2164,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"buffer-from@npm:^1.0.0":
+  version: 1.1.2
+  resolution: "buffer-from@npm:1.1.2"
+  checksum: 0448524a562b37d4d7ed9efd91685a5b77a50672c556ea254ac9a6d30e3403a517d8981f10e565db24e8339413b43c97ca2951f10e399c6125a0d8911f5679bb
+  languageName: node
+  linkType: hard
+
 "buffer@npm:^5.5.0":
   version: 5.7.1
   resolution: "buffer@npm:5.7.1"
@@ -2787,6 +2794,7 @@ __metadata:
     react: ^18.2.0
     react-dom: ^18.2.0
     rimraf: ^5.0.5
+    tsx: ^3.13.0
     turbo: 1.10.14
     type-fest: ^4.3.3
     typescript: 5.2.2
@@ -3045,7 +3053,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild@npm:^0.18.2":
+"esbuild@npm:^0.18.2, esbuild@npm:~0.18.20":
   version: 0.18.20
   resolution: "esbuild@npm:0.18.20"
   dependencies:
@@ -3872,7 +3880,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"get-tsconfig@npm:^4.5.0":
+"get-tsconfig@npm:^4.5.0, get-tsconfig@npm:^4.7.2":
   version: 4.7.2
   resolution: "get-tsconfig@npm:4.7.2"
   dependencies:
@@ -6704,6 +6712,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"source-map-support@npm:^0.5.21":
+  version: 0.5.21
+  resolution: "source-map-support@npm:0.5.21"
+  dependencies:
+    buffer-from: ^1.0.0
+    source-map: ^0.6.0
+  checksum: 43e98d700d79af1d36f859bdb7318e601dfc918c7ba2e98456118ebc4c4872b327773e5a1df09b0524e9e5063bb18f0934538eace60cca2710d1fa687645d137
+  languageName: node
+  linkType: hard
+
 "source-map@npm:0.8.0-beta.0":
   version: 0.8.0-beta.0
   resolution: "source-map@npm:0.8.0-beta.0"
@@ -6713,7 +6731,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"source-map@npm:^0.6.1":
+"source-map@npm:^0.6.0, source-map@npm:^0.6.1":
   version: 0.6.1
   resolution: "source-map@npm:0.6.1"
   checksum: 59ce8640cf3f3124f64ac289012c2b8bd377c238e316fb323ea22fbfe83da07d81e000071d7242cad7a23cd91c7de98e4df8830ec3f133cb6133a5f6e9f67bc2
@@ -7300,6 +7318,23 @@ __metadata:
   peerDependencies:
     typescript: ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
   checksum: 1843f4c1b2e0f975e08c4c21caa4af4f7f65a12ac1b81b3b8489366826259323feb3fc7a243123453d2d1a02314205a7634e048d4a8009921da19f99755cdc48
+  languageName: node
+  linkType: hard
+
+"tsx@npm:^3.13.0":
+  version: 3.13.0
+  resolution: "tsx@npm:3.13.0"
+  dependencies:
+    esbuild: ~0.18.20
+    fsevents: ~2.3.3
+    get-tsconfig: ^4.7.2
+    source-map-support: ^0.5.21
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  bin:
+    tsx: dist/cli.mjs
+  checksum: ef858574e110d16a7ca9bbb3a5edeeafd37026ebed6cdd390c4707ad64005024c55fd3142a8f89732c79176196afa7d27073f586966ff0cae0126159ebd58be4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This should finally fix an issue of shipping an incorrect dependency version on `@discordkit/client` to npm.