### PR TITLE
fix: break vp dep-graph cycle blocking Release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,15 +30,8 @@ jobs:
       # field, but currently don't honor the `development` condition that
       # local dev relies on — they fall through to the `import`/`types`
       # conditions, which require `dist/` to exist. Bare `tsc --noEmit`
-      # works either way because it does honor `customConditions`. Track
-      # at oxc-project/oxc#20704 (conditional-exports false positives).
-      - name: Build @discordkit/core
-        run: vp pack
-        working-directory: packages/core
-      - name: Build @discordkit/client
-        run: vp pack
-        working-directory: packages/client
-
+      # works either way because it does honor `customConditions`.
+      - run: vp run -r build
       - run: vp check
       - run: vp test
 

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -10,7 +10,6 @@
     ".": "./src/index.ts"
   },
   "dependencies": {
-    "@discordkit/core": "workspace:^",
     "@faker-js/faker": "^10.4.0",
     "msw": "^2.14.6",
     "nodejs-snowflake": "^2.0.1",

--- a/packages/test-utils/src/index.ts
+++ b/packages/test-utils/src/index.ts
@@ -17,7 +17,17 @@ import type {
 } from "valibot";
 import { Snowflake } from "nodejs-snowflake";
 import { faker } from "@faker-js/faker";
-import type { DiscordSession } from "@discordkit/core/requests/DiscordSession";
+
+// Structural type matching @discordkit/core's DiscordSession. Inlined
+// rather than imported so test-utils doesn't declare a runtime dep on
+// @discordkit/core — that edge, combined with core's devDep on this
+// package, creates a phantom cycle in vp's task graph (per vp#1610,
+// which follows devDeps in its build-order graph). Any class satisfying
+// these two members will be assignable here.
+interface DiscordSessionLike {
+  endpoint: string;
+  setToken(token: `Bot ${string}` | `Bearer ${string}`): unknown;
+}
 
 type Optional<T, K extends keyof T> = Omit<T, K> & Pick<Partial<T>, K>;
 
@@ -116,7 +126,7 @@ export class MockUtils {
     CustomMock
   >();
 
-  #session: DiscordSession;
+  #session: DiscordSessionLike;
   #msw: SetupServer = setupServer();
   static uid = new Snowflake({ custom_epoch: 1420070400000 });
 
@@ -185,7 +195,7 @@ export class MockUtils {
       MockUtils.applyTransforms(reference, MockUtils.flags(flags));
 
   constructor(
-    discord: DiscordSession,
+    discord: DiscordSessionLike,
     options?: {
       token?: `Bot ${string}` | `Bearer ${string}`;
       customMocks?: Array<

--- a/yarn.lock
+++ b/yarn.lock
@@ -107,7 +107,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@discordkit/test-utils@workspace:packages/test-utils"
   dependencies:
-    "@discordkit/core": "workspace:^"
     "@faker-js/faker": "npm:^10.4.0"
     msw: "npm:^2.14.6"
     nodejs-snowflake: "npm:^2.0.1"


### PR DESCRIPTION
## Summary

Replaces a type-only import from `@discordkit/core` in `@discordkit/test-utils` with an inlined structural interface, and drops `@discordkit/core` from test-utils's runtime dependencies. That severs a cycle in vp's task graph that's been blocking the Release workflow's publish step since v4 merged.

## What was happening

CI passed on v4 (it threaded around the cycle by calling `vp pack` directly per-package). Release failed:

```
Failed to plan tasks from `vp run -r build` in task discordkit#build
* Cycle dependency detected: @discordkit/core#build -> @discordkit/core#build
```

## Why it cycled

This is [voidzero-dev/vite-plus#1610](https://github.com/voidzero-dev/vite-plus/issues/1610) — vp's task-ordering graph follows `devDependencies` and `peerDependencies` in addition to runtime `dependencies` (pnpm and turbo only follow runtime deps for the same reason).

In discordkit:
- `@discordkit/core` declares `@discordkit/test-utils` as a devDep (core's tests use it)
- `@discordkit/test-utils` declared `@discordkit/core` as a runtime dep

vp saw `core → test-utils → core`. Cycle. The Release workflow's publish step uses `vp run build` at the root, which expands to `vp run -r build`, which hit the cycle.

## What test-utils actually needed from core

A single `import type { DiscordSession }`, used in exactly two places — typing the `discord` constructor argument and a private field. Of `DiscordSession`'s public surface, test-utils only ever touched two members:

- `session.setToken(token)` — accepts a `\`Bot ${string}\`` or `\`Bearer ${string}\`` template-literal string
- `session.endpoint` — string property

## Resolution

Inlined a 4-line structural interface in test-utils:

```ts
interface DiscordSessionLike {
  endpoint: string;
  setToken(token: \`Bot ${string}\` | \`Bearer ${string}\`): unknown;
}
```

Any `DiscordSession` remains assignable to `DiscordSessionLike` by TypeScript's structural typing. Removing the `@discordkit/core` runtime dep severs the cycle: vp's graph now has `core → test-utils` as a dead-end.

The CI workflow also reverts the per-package `vp pack` steps from c32bc99 in favor of a single `vp run -r build` now that the recursive form works. Build-before-check stays — that's a separate issue with oxlint's type-aware resolver not honoring `customConditions: development`.

## Verified locally

- `vp run -r build` — completes without cycle, produces dist for core + client
- `vp check` — 0 errors, 13 warnings (pre-existing on config files)
- `vp test` — 267 files / 358 tests pass in ~14s
- `bumpy ci check` — no bump file needed (test-utils is private)

## Test plan
- [ ] CI passes on Node 22, lts, latest
- [ ] Release workflow's `vp run build` step succeeds
- [ ] No regression in `vp check` or `vp test` behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)