### PR TITLE
🐸 Versioned release

### DIFF
--- a/.bumpy/add-oauth-package.md
+++ b/.bumpy/add-oauth-package.md
@@ -1,8 +1,0 @@
----
-"@discordkit/oauth": minor
-"@discordkit/client": minor
----
-
-Added @discordkit/oauth: framework-agnostic Discord OAuth2 utilities (authorization-code flow with PKCE, refresh, client-credentials, revoke), Web-standard login/callback handlers with Next/Astro/Web subpaths. Token responses are defined by Valibot schemas (source of truth for the inferred types) and validated at runtime; valibot is a peer dependency.
-
-Added `getCurrentAuthorizationInfo` (`GET /oauth2/@me`) to @discordkit/client under a new `oauth2` endpoint group — it's a bearer-authenticated Discord API call, so it lives alongside the other client Fetchers (use it inside an `asUser` scope) rather than in the OAuth-flow package.

--- a/.bumpy/adopt-saeris-configs.md
+++ b/.bumpy/adopt-saeris-configs.md
@@ -1,7 +1,0 @@
----
----
-
-Contributor tooling only — adopts `@saeris/configs@^1.6.1` for the
-shared lint/fmt/tsconfig surface and replaces our hand-rolled root
-configs with thin local-override blocks. No consumer-visible behavior
-change, no public API change. See [#55](https://github.com/discordkit/discordkit/pull/55).

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -1,6 +1,13 @@
 # @discordkit/client
 
 
+
+## 4.1.0
+<sub>2026-06-12</sub>
+
+- [#56](https://github.com/discordkit/discordkit/pull/56)  *(minor)* Thanks [@Saeris](https://github.com/Saeris)! - Added @discordkit/oauth: framework-agnostic Discord OAuth2 utilities (authorization-code flow with PKCE, refresh, client-credentials, revoke), Web-standard login/callback handlers with Next/Astro/Web subpaths. Token responses are defined by Valibot schemas (source of truth for the inferred types) and validated at runtime; valibot is a peer dependency.
+  Added `getCurrentAuthorizationInfo` (`GET /oauth2/@me`) to @discordkit/client under a new `oauth2` endpoint group — it's a bearer-authenticated Discord API call, so it lives alongside the other client Fetchers (use it inside an `asUser` scope) rather than in the OAuth-flow package.
+
 ## 4.0.0
 <sub>2026-06-04</sub>
 

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@discordkit/client",
   "description": "A REST API Client for Discord",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "license": "MIT",
   "author": "Drake Costa <drake@saeris.gg> (https://saeris.gg)",
   "keywords": [

--- a/packages/oauth/CHANGELOG.md
+++ b/packages/oauth/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## 0.1.0
+<sub>2026-06-12</sub>
+
+- [#56](https://github.com/discordkit/discordkit/pull/56)  *(minor)* Thanks [@Saeris](https://github.com/Saeris)! - Added @discordkit/oauth: framework-agnostic Discord OAuth2 utilities (authorization-code flow with PKCE, refresh, client-credentials, revoke), Web-standard login/callback handlers with Next/Astro/Web subpaths. Token responses are defined by Valibot schemas (source of truth for the inferred types) and validated at runtime; valibot is a peer dependency.
+  Added `getCurrentAuthorizationInfo` (`GET /oauth2/@me`) to @discordkit/client under a new `oauth2` endpoint group — it's a bearer-authenticated Discord API call, so it lives alongside the other client Fetchers (use it inside an `asUser` scope) rather than in the OAuth-flow package.

--- a/packages/oauth/package.json
+++ b/packages/oauth/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@discordkit/oauth",
   "description": "Framework-agnostic Discord OAuth2 utilities",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "license": "MIT",
   "author": "Drake Costa <drake@saeris.gg> (https://saeris.gg)",
   "keywords": [


### PR DESCRIPTION
<a href="https://bumpy.varlock.dev"><img src="https://raw.githubusercontent.com/dmno-dev/bumpy/main/images/frog-clipboard.png" alt="bumpy-frog" width="60" align="left" style="image-rendering: pixelated;" title="Hi! I'm bumpy!" /></a>

This PR was created and will be kept in sync by [bumpy](https://bumpy.varlock.dev) based on your bump files (in `.bumpy/`). Merge it when you are ready to release the packages listed below:
<br clear="left" />

### <a href="https://bumpy.varlock.dev" title="Minor releases"><img src="https://raw.githubusercontent.com/dmno-dev/bumpy/main/images/frog-minor.png" alt="minor" width="52" style="image-rendering: pixelated;" align="right" /></a> Minor releases

#### `@discordkit/client` 4.0.0 → **4.1.0** <sub>[CHANGELOG.md](https://github.com/discordkit/discordkit/pull/57/changes#diff-2429a8f921914f4c5e53adb2d920ad333cc06718368e993d166909c1b6b8ff14)</sub>

- Added @discordkit/oauth: framework-agnostic Discord OAuth2 utilities (authorization-code flow with PKCE, refresh, client-credentials, revoke), Web-standard login/callback handlers with Next/Astro/Web subpaths. Token responses are defined by Valibot schemas (source of truth for the inferred types) and validated at runtime; valibot is a peer dependency. ([bump file](https://github.com/discordkit/discordkit/pull/57/changes#diff-7f7d5086c66ed77fee97fa4add89332969c9a5c1b324b9f863b780aa636eaa76))
  Added `getCurrentAuthorizationInfo` (`GET /oauth2/@me`) to @discordkit/client under a new `oauth2` endpoint group — it's a bearer-authenticated Discord API call, so it lives alongside the other client Fetchers (use it inside an `asUser` scope) rather than in the OAuth-flow package.

#### `@discordkit/oauth` 0.0.0 → **0.1.0** <sub>[CHANGELOG.md](https://github.com/discordkit/discordkit/pull/57/changes#diff-9b035b2bdf1a5ade19eec6fb31d4cbdee94e05cfb6298d106d8683a728fa9784)</sub>

- Added @discordkit/oauth: framework-agnostic Discord OAuth2 utilities (authorization-code flow with PKCE, refresh, client-credentials, revoke), Web-standard login/callback handlers with Next/Astro/Web subpaths. Token responses are defined by Valibot schemas (source of truth for the inferred types) and validated at runtime; valibot is a peer dependency. ([bump file](https://github.com/discordkit/discordkit/pull/57/changes#diff-7f7d5086c66ed77fee97fa4add89332969c9a5c1b324b9f863b780aa636eaa76))
  Added `getCurrentAuthorizationInfo` (`GET /oauth2/@me`) to @discordkit/client under a new `oauth2` endpoint group — it's a bearer-authenticated Discord API call, so it lives alongside the other client Fetchers (use it inside an `asUser` scope) rather than in the OAuth-flow package.
