### PR TITLE
🐸 Versioned release

### DIFF
--- a/.bumpy/zany-mild-reef.md
+++ b/.bumpy/zany-mild-reef.md
@@ -1,5 +1,0 @@
----
-"@discordkit/native": minor
----
-
-Added `statusDisplayType` to rich-presence activities (`ActivityInput`) — controls which field Discord surfaces in the user's text status: `name` (the app name, the default), `state`, or `details`. Maps the string key to `Discord_Activity_SetStatusDisplayType`; omit to leave the SDK default. Flows through the `@discordkit/electron` and `@discordkit/tauri` `setActivity` bridges unchanged.

--- a/packages/electron/CHANGELOG.md
+++ b/packages/electron/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+
+## 0.1.1
+<sub>2026-07-22</sub>
+
+- *(patch)* Updated dependency `@discordkit/native` v0.2.0
+
 ## 0.1.0
 <sub>2026-06-22</sub>
 

--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@discordkit/electron",
   "description": "Electron adapter for @discordkit/native — run the Discord Social SDK in the main process and reach it from the renderer over a typed IPC bridge",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "license": "MIT",
   "author": "Drake Costa <drake@saeris.gg> (https://saeris.gg)",
   "keywords": [

--- a/packages/native/CHANGELOG.md
+++ b/packages/native/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+
+## 0.2.0
+<sub>2026-07-22</sub>
+
+- [#67](https://github.com/discordkit/discordkit/pull/67)  *(minor)* Thanks [@xwxfox](https://github.com/xwxfox)!
+  Added `statusDisplayType` to rich-presence activities (`ActivityInput`) — controls which field Discord surfaces in the user's text status: `name` (the app name, the default), `state`, or `details`. Maps the string key to `Discord_Activity_SetStatusDisplayType`; omit to leave the SDK default. Flows through the `@discordkit/electron` and `@discordkit/tauri` `setActivity` bridges unchanged.
+
 ## 0.1.0
 <sub>2026-06-22</sub>
 

--- a/packages/native/package.json
+++ b/packages/native/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@discordkit/native",
   "description": "Functional TypeScript bridge to the Discord Social SDK for Electron, Tauri, and other native desktop runtimes",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "license": "MIT",
   "author": "Drake Costa <drake@saeris.gg> (https://saeris.gg)",
   "keywords": [

--- a/packages/tauri/CHANGELOG.md
+++ b/packages/tauri/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+
+## 0.1.1
+<sub>2026-07-22</sub>
+
+- *(patch)* Updated dependency `@discordkit/native` v0.2.0
+
 ## 0.1.0
 <sub>2026-06-22</sub>
 

--- a/packages/tauri/package.json
+++ b/packages/tauri/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@discordkit/tauri",
   "description": "Tauri adapter for @discordkit/native — run the Discord Social SDK in a Node sidecar and reach it from the webview over a typed kkrpc bridge",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "license": "MIT",
   "author": "Drake Costa <drake@saeris.gg> (https://saeris.gg)",
   "keywords": [


### PR DESCRIPTION
<a href="https://bumpy.varlock.dev"><img src="https://raw.githubusercontent.com/dmno-dev/bumpy/main/images/frog-clipboard.png" alt="bumpy-frog" width="60" align="left" style="image-rendering: pixelated;" title="Hi! I'm bumpy!" /></a>

This PR was created and will be kept in sync by [bumpy](https://bumpy.varlock.dev) based on your bump files (in `.bumpy/`). Merge it when you are ready to release the packages listed below:
<br clear="left" />

### <a href="https://bumpy.varlock.dev" title="Minor releases"><img src="https://raw.githubusercontent.com/dmno-dev/bumpy/main/images/frog-minor.png" alt="minor" width="52" style="image-rendering: pixelated;" align="right" /></a> Minor releases

#### `@discordkit/native` 0.1.0 → **0.2.0** <sub>[CHANGELOG.md](https://github.com/discordkit/discordkit/pull/68/changes#diff-9445ddf84f5f4e2a0d902b73f54f8ad62acf40f59af86ff6e3a8ef1805352cf6)</sub>

- Added `statusDisplayType` to rich-presence activities (`ActivityInput`) — controls which field Discord surfaces in the user's text status: `name` (the app name, the default), `state`, or `details`. Maps the string key to `Discord_Activity_SetStatusDisplayType`; omit to leave the SDK default. Flows through the `@discordkit/electron` and `@discordkit/tauri` `setActivity` bridges unchanged. ([bump file](https://github.com/discordkit/discordkit/pull/68/changes#diff-a06bcfbd1d407a1938be017776273e44c195faf8ff15c6e194daf46e77f02c6d))

### <a href="https://bumpy.varlock.dev" title="Patch releases"><img src="https://raw.githubusercontent.com/dmno-dev/bumpy/main/images/frog-patch.png" alt="patch" width="52" style="image-rendering: pixelated;" align="right" /></a> Patch releases

#### `@discordkit/electron` 0.1.0 → **0.1.1** _(dep)_ <sub>[CHANGELOG.md](https://github.com/discordkit/discordkit/pull/68/changes#diff-0f56f06abeb1f1a6c55bd4609cc160149ea7c097214fbd275ea634267ffdd665)</sub>

- Updated dependencies

#### `@discordkit/tauri` 0.1.0 → **0.1.1** _(dep)_ <sub>[CHANGELOG.md](https://github.com/discordkit/discordkit/pull/68/changes#diff-5917869112e84c92197736ee206aee37bb8c624163a28a3c4962c72c680c54b2)</sub>

- Updated dependencies
